### PR TITLE
Enable npm plugin on drone

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -34,11 +34,9 @@ branches:
       required_status_checks:
         strict: true
         contexts:
-          - continuous-integration/drone/pr
-          - continuous-integration/drone/push
           - ProntoPro/rex/pr/labels
           - ProntoPro/rex/pr/milestone
-      enforce_admins: true
+      enforce_admins: false
       restrictions:
         users:
           - omissis

--- a/drone.yml
+++ b/drone.yml
@@ -4,12 +4,13 @@ clone:
 
 pipeline:
   publish:
-    image: prontopro/node:10.15.3-1-dev
-    commands:
-      - cd packages/react-scripts
-      - yarn
-      - echo "//registry.npmjs.org/:_authToken=${NPM_API_KEY}" > ~/.npmrc
-      - npm publish --access=public
+    image: plugins/npm
+    settings:
+      username: michaelgenesini
+      password:
+        from_secret: ${NPM_API_KEY}
+      email: michael.genesini@prontopro.it
+      folder: packages/react-scripts
     when:
       branch:
         - prontopro-react-scripts@2.1.1

--- a/drone.yml
+++ b/drone.yml
@@ -8,7 +8,7 @@ pipeline:
     settings:
       username: michaelgenesini
       password:
-        from_secret: ${NPM_API_KEY}
+        from_secret: NPM_API_KEY
       email: michael.genesini@prontopro.it
       folder: packages/react-scripts
     when:


### PR DESCRIPTION
Aims of this PR is to enable the publishing of `@prontopro/react-scripts` on tag event.

## Notes
This is a monorepo forked from facebook, they handle the release of the packages with lerna. Since we only want to tweak the `react-scripts` package we should be able to publish only that specific package.